### PR TITLE
feat: add type annotations

### DIFF
--- a/quick_xmltodict.pyi
+++ b/quick_xmltodict.pyi
@@ -1,0 +1,5 @@
+from typing import Any
+
+def parse(xml: str) -> dict[str, Any]:
+    """Parse an XML string and convert it into a dictionary."""
+


### PR DESCRIPTION
Without type stubs, IDEs and type checkers cannot see what's in this package.

References:
- https://www.maturin.rs/project_layout.html?highlight=py.typed#adding-python-type-information
- https://docs.python.org/3/library/typing.html

Current:
![image](https://github.com/user-attachments/assets/ecdbbd27-2de6-473b-bc77-fd7cb86b1a50)

After:
![image](https://github.com/user-attachments/assets/1536707f-368f-41b6-b946-43d15358eb14)
