### PR TITLE
fix: add typing classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
     "Topic :: Text Processing :: Markup :: XML",
+    "Typing :: Typed",
 ]
 dependencies = []
 dynamic = ["version"] # Source version from Cargo.toml's package.version


### PR DESCRIPTION
It's recommended for packages to use this classifier if they provide type hints, which we now do.